### PR TITLE
add new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Add the plugin to your rebar config:
 
 ```
 {plugins, [
-    {rebar3_eunit_tests_plugin, {git, "https://github.com/AoiMoe/rebar3_eunit_tests_plugin.git", {tag, "v1.0.0"}}}
+    {rebar3_eunit_tests_plugin, {git, "https://github.com/AoiMoe/rebar3_eunit_tests_plugin.git", {tag, "v1.0.1"}}}
 ]}.
 ```
 
@@ -17,18 +17,28 @@ $ rebar3 help eunit_tests
 ===> Fetching rebar3_eunit_tests_plugin ...
 ===> Compiling rebar3_eunit_tests_plugin
 A rebar plugin to invoke eunit with overriding eunit_tests value by command line options.
-Usage: rebar3 eunit_tests [-t <tests>] [-m <default_module>]
+Usage: rebar3 eunit_tests [-r <raw>] [-t <tests>] [-m <default_module>]
                           [--function_suffix <function_suffix>]
-                          [--module_suffix <module_suffix>] [-c <cover>]
+                          [--module_suffix <module_suffix>] [--app <app>]
+                          [--application <application>] [-d <dir>]
+                          [-f <file>] [-s <suite>] [-c <cover>]
                           [--cover_export_name <cover_export_name>]
                           [-v <verbose>] [--name <name>]
                           [--sname <sname>] [--setcookie <setcookie>]
 
+  -r, --raw             Raw eunit_tests value. Proir all other options. 
+                        Example: "[{module, foo_tests}]"
   -t, --tests           Comma separated list of test functions. Form: 
                         modname:funname | funname
   -m, --default_module  Default module.
   --function_suffix     Function suffix. Defaults to "_test_".
   --module_suffix       Module suffix. Defaults to "_tests".
+  --app                 Comma separated list of application test suites to 
+                        run.
+  --application         Same as "app"
+  -d, --dir             Comma separated list of dirs to load tests from.
+  -f, --file            Comma separated list of files to load tests from.
+  -s, --suite           Comma separated list of modules to load tests from.
   -c, --cover           Generate cover data. Defaults to false.
   --cover_export_name   Base name of the coverdata file to write.
   -v, --verbose         Verbose output. Defaults to false.

--- a/src/rebar3_eunit_tests_plugin.app.src
+++ b/src/rebar3_eunit_tests_plugin.app.src
@@ -1,12 +1,12 @@
 {application, rebar3_eunit_tests_plugin,
  [{description, "A rebar plugin"},
-  {vsn, "1.0.0"},
+  {vsn, "1.0.1"},
   {registered, []},
   {applications,
    [kernel,
     stdlib
    ]},
-  {env,[]},
+  {env, []},
   {modules, []},
 
   {maintainers, []},

--- a/src/rebar3_eunit_tests_plugin_prv.erl
+++ b/src/rebar3_eunit_tests_plugin_prv.erl
@@ -73,6 +73,7 @@ override_state(State0) ->
     ModSuffix = proplists:get_value(module_suffix, RawOpts, "_tests"),
     try
         if Raw =/= [] ->
+                if Tests0 =/= [] -> error("Exclusive --raw and --tests"); true -> ok end,
                 check_exclusive_options(RawOpts),
                 Tokens =
                     case erl_scan:string(Raw ++ ".") of

--- a/src/rebar3_eunit_tests_plugin_prv.erl
+++ b/src/rebar3_eunit_tests_plugin_prv.erl
@@ -74,7 +74,7 @@ override_state(State0) ->
     try
         if Raw =/= [] ->
                 if Tests0 =/= [] -> error("Exclusive --raw and --tests"); true -> ok end,
-                check_exclusive_options(RawOpts),
+                check_exclusive_options(raw, RawOpts),
                 Tokens =
                     case erl_scan:string(Raw ++ ".") of
                         {ok, T, _} -> T;
@@ -93,7 +93,7 @@ override_state(State0) ->
                    true ->
                         %% rebar3 eunit_tests -m module
                         %%   -> [{module, module_tests}]
-                        check_exclusive_options(RawOpts),
+                        check_exclusive_options(default_module, RawOpts),
                         Tests = [{module, list_to_atom(DefModule ++ ModSuffix)}]
                 end;
            true ->
@@ -107,7 +107,7 @@ override_state(State0) ->
                 %%       {generator, mod_tests, fun2_test_},
                 %%       ...
                 %%       {generator, mod_tests, funN_test_}]
-                check_exclusive_options(RawOpts),
+                check_exclusive_options(tests, RawOpts),
                 Tests1 = re:split(Tests0, ",", [{return, list}]),
                 Tests =
                     lists:map(
@@ -132,8 +132,8 @@ override_state(State0) ->
         error:Reason -> {error, lists:flatten(Reason)}
     end.
 
--spec check_exclusive_options([proplists:property()]) -> ok.
-check_exclusive_options(RawOpts) ->
+-spec check_exclusive_options(atom(), [proplists:property()]) -> ok.
+check_exclusive_options(Opt, RawOpts) ->
     lists:foreach(fun(K) ->
                           case K of
                               app -> true;
@@ -142,5 +142,5 @@ check_exclusive_options(RawOpts) ->
                               file -> true;
                               suite -> true;
                               _ -> false
-                          end andalso error(io_lib:format("Exclusive --~p and -t", [K]))
+                          end andalso error(io_lib:format("Exclusive --~p and --~p", [Opt, K]))
                   end, proplists:get_keys(RawOpts)).

--- a/src/rebar3_eunit_tests_plugin_prv.erl
+++ b/src/rebar3_eunit_tests_plugin_prv.erl
@@ -82,7 +82,8 @@ override_state(State0) ->
                     end,
                 Tests =
                     case erl_parse:parse_term(Tokens) of
-                        {ok, Term} -> Term;
+                        {ok, Term} when is_list(Term) -> Term;
+                        {ok, Term} -> [Term];
                         _ -> error(io_lib:format("Cannot parse --raw: ~p", [Raw]))
                     end;
            Tests0 =:= [] ->


### PR DESCRIPTION
## changes
- allow to omit '--tests' option, that means equiv to 'rebar3 eunit' .  Additionally, some options are added to be passed through to eunit provider.
- add '--raw' option to specify raw 'eunit_tests' config value.